### PR TITLE
Fix bug in network tests

### DIFF
--- a/CluelessBackend/ServerInitializer.cs
+++ b/CluelessBackend/ServerInitializer.cs
@@ -48,7 +48,7 @@ namespace CluelessBackend
             var gameInstanceService = new GameInstanceService();
             var unused = new ChatService(gameInstanceService);
             using var networkServer = new CluelessNetworkServer(gameInstanceService);
-            while (true) networkServer.ListenForConnection();
+            while (true) networkServer.ListenForConnection(listenContinuously: true);
 
             // Disable warning from static code analysis. We don't expect this function to ever return.
             // ReSharper disable once FunctionNeverReturns

--- a/CluelessNetwork/BackendNetworkInterfaces/CluelessNetworkServer.cs
+++ b/CluelessNetwork/BackendNetworkInterfaces/CluelessNetworkServer.cs
@@ -66,7 +66,7 @@ namespace CluelessNetwork.BackendNetworkInterfaces
         /// joining one
         /// </summary>
         /// <param name="client">TCP client handle for the incoming connection</param>
-        private void HandleClientConnect(TcpClient client)
+        private void HandleClientConnect(TcpClient client, bool listenContinuously)
         {
             // Get the connection info from the connecting client
             var frontendConnection = TryBuildPlayerNetworkModel(client.GetStream());
@@ -89,20 +89,21 @@ namespace CluelessNetwork.BackendNetworkInterfaces
             if (Settings.PrintNetworkDebugMessagesToConsole)
                 Console.WriteLine("Adding player to game instance");
             _gameInstanceService.AddPlayerToGameInstance(frontendConnection);
-            Task.Run(frontendConnection.ListenForUpdatesContinuously);
+            if (listenContinuously)
+                Task.Run(frontendConnection.ListenForUpdatesContinuously);
         }
 
         /// <summary>
         /// Waits for a connection, and starts handling it when it arrives
         /// </summary>
-        public void ListenForConnection()
+        public void ListenForConnection(bool listenContinuously)
         {
             try
             {
                 // Accept a TCP connection
                 var client = _tcpListener.AcceptTcpClient();
                 // Don't block listening for more clients while a client is connecting. Run connect handling on a separate thread.
-                HandleClientConnect(client);
+                HandleClientConnect(client, listenContinuously);
             }
             catch (SocketException socketException)
             {

--- a/CluelessTests/NetworkTests/NetworkServerTests.cs
+++ b/CluelessTests/NetworkTests/NetworkServerTests.cs
@@ -36,7 +36,7 @@ namespace CluelessTests.NetworkTests
 
                 // Connect two clients to the server
                 using var client = new CluelessNetworkClient("127.0.0.1", true, "ClientName");
-                server.ListenForConnection();
+                server.ListenForConnection(listenContinuously: false);
 
                 // Sanity check: we should have two players on the server
                 gameInstanceService.GameInstance!.Players.Count.Should().Be(1);
@@ -78,9 +78,9 @@ namespace CluelessTests.NetworkTests
 
                 // Connect two clients to the server
                 using var client1 = new CluelessNetworkClient("127.0.0.1", true, "Client 1");
-                server.ListenForConnection();
+                server.ListenForConnection(listenContinuously: false);
                 using var client2 = new CluelessNetworkClient("127.0.0.1", false, "Client 1");
-                server.ListenForConnection();
+                server.ListenForConnection(listenContinuously: false);
 
                 // Sanity check: we should have two players on the server
                 gameInstanceService.GameInstance!.Players.Count.Should().Be(2);
@@ -134,7 +134,7 @@ namespace CluelessTests.NetworkTests
                 using var client = new CluelessNetworkClient("127.0.0.1", true, string.Empty);
 
                 // Accept connection and send requests to game instance service
-                server.ListenForConnection();
+                server.ListenForConnection(listenContinuously: false);
 
                 // Verify that we asked the game instance service mock to do all the correct things 
                 gameInstanceServiceMock.Invocations.Count.Should().Be(2);
@@ -165,7 +165,7 @@ namespace CluelessTests.NetworkTests
                 using var client = new CluelessNetworkClient("127.0.0.1", true, string.Empty);
 
                 // Accept one connection and run logic
-                server.ListenForConnection();
+                server.ListenForConnection(listenContinuously: false);
 
                 var backendPlayerNetworkModel = gameInstanceService.GameInstance!.Players.Single();
                 var playerOptionCollection = new PlayerOptionCollection


### PR DESCRIPTION
After initializing a connection, don't wait for updates (and intercept test messages)